### PR TITLE
Added support for the .NET Core CLI template engine

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "generatorVersions": "[1.0.0.0-*)",
+    "author": "Thomas Hansen",
+    "classifications": ["Web"],
+    "name": "Super DRY Magic",
+    "identity": "gaiasoul.super.dry.magic",
+    "shortName": "dry-magic",
+    "precedence": "100",
+    "tags": {
+        "language": "C#"
+    },
+    "sourceName": "magic",
+    "preferNameDirectory": true,
+    "sources": [
+      {
+        "source": "./",
+        "target": "./",
+        "exclude": [
+          ".template-config/**",
+          ".git/**"
+        ]
+      }
+    ],
+    "symbols": {
+        "app-title": {
+          "type": "parameter",
+          "datatype": "string",
+          "description": "The title of the application (shown in Swagger)",
+          "replaces": "TITLE",
+          "defaultValue": "Magic"
+        },
+        "app-desc": {
+            "type": "parameter",
+            "datatype": "string",
+            "description": "A description of the application (shown in Swagger)",
+            "replaces": "DESC",
+            "defaultValue": "An Affero GPL Licensed starter kit for ASP.NET Core"
+        },
+        "app-contact-name": {
+            "type": "parameter",
+            "datatype": "string",
+            "description": "The name of the main developer contact (shown in Swagger)",
+            "replaces": "MAIN_CONTACT",
+            "defaultValue": "Thomas Hansen"
+        },
+        "app-contact-email": {
+            "type": "parameter",
+            "datatype": "string",
+            "description": "The email address of the main developer contact (shown in Swagger)",
+            "replaces": "MAIN_EMAIL",
+            "defaultValue": "thomas@gaiasoul.com"
+        },
+        "app-contact-url": {
+            "type": "parameter",
+            "datatype": "string",
+            "description": "The url of the main developer contact (shown in Swagger)",
+            "replaces": "MAIN_URL",
+            "defaultValue": "gaiasoul.com"
+        },
+        "licence-name": {
+            "type": "parameter",
+            "datatype": "string",
+            "description": "The name of the licence for this applicattion (shown in Swagger)",
+            "replaces": "LICENCE",
+            "defaultValue": "Affero GPL"
+        }
+    }
+  }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,97 @@ becomes automagically documented for you!
 * Unzip and open _"magic.sln"_ in Visual Studio
 * Click F5
 
+### .NET Core CLI Template
+
+This repository also includes a .NET Core CLI template which can be installed by:
+
+* Clone the repo
+* Open a terminal in the parent of the repo
+  * i.e. one level above the root of the repo
+  * if you cloned to `~/code/magic`, then open the terminal at `~/code/`
+* Run the following command: `dotnet new --install magic`
+
+This will install the contents of this repo as a template, which you can use alongside the .NET Core CLI in the following manner:
+
+`dotnet new magic --help`
+
+This will show the list of command line switches which are available, along with descriptions and their default values.
+
+```
+Super DRY Magic (C#)
+Author: Thomas Hansen
+Options:                                                                                      
+  -at|--app-title           The title of the application (shown in Swagger)                   
+                            string - Optional                                                 
+                            Default: Magic                                                    
+
+  -ad|--app-desc            A description of the application (shown in Swagger)               
+                            string - Optional                                                 
+                            Default: An Affero GPL Licensed starter kit for ASP.NET Core      
+
+  -acn|--app-contact-name   The name of the main developer contact (shown in Swagger)         
+                            string - Optional                                                 
+                            Default: Thomas Hansen                                            
+
+  -ace|--app-contact-email  The email address of the main developer contact (shown in Swagger)
+                            string - Optional                                                 
+                            Default: thomas@gaiasoul.com                                      
+
+  -acu|--app-contact-url    The url of the main developer contact (shown in Swagger)          
+                            string - Optional                                                 
+                            Default: gaiasoul.com                                             
+
+  -ln|--licence-name        The name of the licence for this applicattion (shown in Swagger)  
+                            string - Optional                                                 
+                            Default: Affero GPL
+```
+
+Creating a new instance of the magic code base is as simple as issuing the following command:
+
+`dotnet new magic --name super.dry.magic.application`
+
+After the scaffolding process completes, you will find a copy of the code base in the `./super.dry.magic.application/` directory. The `--name` switch will take care of full namespace replacement, and the optional switches (shown above) will have their default values supplied.
+
+As an example of how to override them, here is the same command but with some of the optional switches provided:
+
+`dotnet new magic --name super.dry.magic.application -acn "Jamie Taylor" -ace "jamie@gaprogman.com" -acu "https://dotnetcore.show"`
+
+This is replace the contents of the following lines in the startup.cs class:
+
+``` csharp
+c.SwaggerDoc("v1", new Info
+    {
+        Title = "TITLE",
+        Version = "v1",
+        Description = "DESC",
+        TermsOfService = "LICENCE",
+        Contact = new Contact()
+        {
+            Name = "MAIN_CONTACT",
+            Email = "MAIN_EMAIL",
+            Url = "MAIN_URL"
+        }
+    });
+```
+
+With the following:
+
+``` csharp
+c.SwaggerDoc("v1", new Info
+    {
+        Title = "Magic",
+        Version = "v1",
+        Description = "Some test magic",
+        TermsOfService = "Affero GPL",
+        Contact = new Contact()
+        {
+            Name = "Jamie Taylor",
+            Email = "jamie@gaprogman.com",
+            Url = "https://dotnetcore.show"
+        }
+    });
+```
+
 ## Features
 
 Magic supports MySQL, MSSQL and SQLIte out of the box, but adding support for your own relational database type, can be done with three lines

--- a/magic.backend/Startup.cs
+++ b/magic.backend/Startup.cs
@@ -69,11 +69,16 @@ namespace magic.backend
             {
                 c.SwaggerDoc("v1", new Info
                 {
-                    Title = "Magic",
+                    Title = "TITLE",
                     Version = "v1",
-                    Description = "An Affero GPL Licensed starter kit for ASP.NET Core",
-                    TermsOfService = "Affero GPL",
-                    Contact = new Contact() { Name = "Thomas Hansen", Email = "thomas@gaiasoul.com", Url = "gaiasoul.com" }
+                    Description = "DESC",
+                    TermsOfService = "LICENCE",
+                    Contact = new Contact()
+                    {
+                        Name = "MAIN_CONTACT",
+                        Email = "MAIN_EMAIL",
+                        Url = "MAIN_URL"
+                    }
                 });
                 foreach (var idxFile in Directory.GetFiles(AppContext.BaseDirectory, "*.xml"))
                 {
@@ -89,9 +94,13 @@ namespace magic.backend
             InitializeServices.Initialize(Kernel);
 
             if (env.IsDevelopment())
+            {
                 app.UseDeveloperExceptionPage();
+            }
             else
+            {
                 app.UseHsts();
+            }
 
             app.UseHttpsRedirection();
             app.UseCors("DefaultCors");
@@ -100,7 +109,7 @@ namespace magic.backend
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Magic");
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "TITLE");
             });
         }
 


### PR DESCRIPTION
These changes provide the following functionality:

- The ability to quickly scaffold a new instance of the code base with arbitrary details on:
  - Title of the application
  - Lead developer contact details
  - License used

This is provided by the `./template.config/template.json` file. This can also be used in conjunction with the `dotnet pack` command to create a NuGet package of the template for easier installation on machines which have the .NET Core CLI installed on them.

Also included are two opinionated changes on `{` and `}` positioning around if statements (i.e. `magic.backend/startup.cs`: lines 97 to 103). Please feel free to remove these changes if you wish, as they are not important to the new functionality and are based on my personal taste.