### PR TITLE
Add math.sum and math.average slots

### DIFF
--- a/plugins/magic.lambda.math/magic.lambda.math.tests/MathTests.cs
+++ b/plugins/magic.lambda.math/magic.lambda.math.tests/MathTests.cs
@@ -332,5 +332,41 @@ math.dot
    get-nodes:x:@.list2/*");
             Assert.Equal(0.936D, lambda.Children.Skip(2).First().Value);
         }
+
+        [Fact]
+        public void Sum_01()
+        {
+            var lambda = Common.Evaluate(@"
+
+math.sum
+   :int:1
+   :int:2
+   :int:3");
+            Assert.Equal(6, lambda.Children.First().Value);
+        }
+
+        [Fact]
+        public void Sum_NoBaseThrows()
+        {
+            Assert.Throws<HyperlambdaException>(() => Common.Evaluate(@"math.sum"));
+        }
+
+        [Fact]
+        public void Average_01()
+        {
+            var lambda = Common.Evaluate(@"
+
+math.average
+   :int:2
+   :int:4
+   :int:6");
+            Assert.Equal(4, lambda.Children.First().Value);
+        }
+
+        [Fact]
+        public void Average_NoBaseThrows()
+        {
+            Assert.Throws<HyperlambdaException>(() => Common.Evaluate(@"math.average"));
+        }
     }
 }

--- a/plugins/magic.lambda.math/magic.lambda.math/aggregates/Average.cs
+++ b/plugins/magic.lambda.math/magic.lambda.math/aggregates/Average.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using magic.node;
+using magic.signals.contracts;
+using magic.lambda.math.utilities;
+
+namespace magic.lambda.math.aggregates
+{
+    /// <summary>
+    /// [math.average] slot calculating the mean of all numbers.
+    /// </summary>
+    [Slot(Name = "math.average")]
+    public class Average : ISlotAsync
+    {
+        /// <summary>
+        /// Implementation of slot.
+        /// </summary>
+        /// <param name="signaler">Signaler used to raise the signal.</param>
+        /// <param name="input">Arguments to slot.</param>
+        /// <returns>An awaitable task.</returns>
+        public async Task SignalAsync(ISignaler signaler, Node input)
+        {
+            await signaler.SignalAsync("eval", input);
+            dynamic sum = Utilities.GetBase(input);
+            int count = 1;
+            foreach (var idx in Utilities.AllButBase(input))
+            {
+                sum += idx;
+                count++;
+            }
+            input.Clear();
+            input.Value = sum / count;
+        }
+    }
+}

--- a/plugins/magic.lambda.math/magic.lambda.math/aggregates/Sum.cs
+++ b/plugins/magic.lambda.math/magic.lambda.math/aggregates/Sum.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using magic.node;
+using magic.signals.contracts;
+using magic.lambda.math.utilities;
+
+namespace magic.lambda.math.aggregates
+{
+    /// <summary>
+    /// [math.sum] slot returning the total of all numbers.
+    /// </summary>
+    [Slot(Name = "math.sum")]
+    public class Sum : ISlotAsync
+    {
+        /// <summary>
+        /// Implementation of slot.
+        /// </summary>
+        /// <param name="signaler">Signaler used to raise the signal.</param>
+        /// <param name="input">Arguments to slot.</param>
+        /// <returns>An awaitable task.</returns>
+        public async Task SignalAsync(ISignaler signaler, Node input)
+        {
+            await signaler.SignalAsync("eval", input);
+            dynamic sum = Utilities.GetBase(input);
+            foreach (var idx in Utilities.AllButBase(input))
+            {
+                sum += idx;
+            }
+            input.Clear();
+            input.Value = sum;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add aggregate slots for `math.sum` and `math.average`
- test typical usage and error cases

## Testing
- `dotnet test plugins/magic.lambda.math/magic.lambda.math.tests/magic.lambda.math.tests.csproj --no-build` *(fails: `dotnet: command not found`)*